### PR TITLE
fix(elements): Centered thumb & fixed disabled state

### DIFF
--- a/packages/elements/src/react/ui/components/switch.css
+++ b/packages/elements/src/react/ui/components/switch.css
@@ -61,39 +61,25 @@
 	background-color: hsl(var(--kf-switch-bg-checked));
 }
 
-&:hover {
+.switch-root[data-state="checked"]:hover .switch-track {
 	background-color: hsl(var(--kf-switch-bg-checked-hover));
 }
 
-&:active {
-	background-color: hsl(var(--kf-switch-bg-checked));
+/* Disabled states */
+.switch-root[data-disabled] {
+	cursor: not-allowed;
 }
 
-& .switch-track-disabled {
-	background-color: hsl(var(--kf-switch-bg-checked));
-}
-
-&[data-state="checked"] .switch-track-disabled .switch-thumb {
-	background-color: hsl(var(--kf-switch-thumb-bg));
-	opacity: 0.5;
-}
-}
-
-/* Disabled track */
-.switch-track-disabled {
+.switch-root[data-disabled] .switch-track {
 	background-color: hsl(var(--kf-switch-bg-disabled));
-	padding: 3px;
+	opacity: 0.4;
 	box-shadow: inset 0 0 0 1px hsl(var(--kf-stroke-soft-200));
 }
 
-.switch-track-disabled[data-state="checked"] {
+.switch-root[data-disabled][data-state="checked"] .switch-track {
 	background-color: hsl(var(--kf-switch-bg-checked));
 	opacity: 0.4;
 	box-shadow: none;
-}
-
-.switch-track-disabled[data-state="checked"] .switch-thumb {
-	transform: translateX(var(--kf-switch-thumb-translate));
 }
 
 /* Switch thumb */
@@ -104,6 +90,7 @@
 	width: var(--kf-switch-thumb-size);
 	height: var(--kf-switch-thumb-size);
 	transition: transform var(--kf-switch-duration) var(--kf-switch-ease);
+	transform: translateX(0);
 }
 
 /* Thumb states */
@@ -111,9 +98,8 @@
 	content: "";
 	position: absolute;
 	inset-block: 0;
-	left: 50%;
-	width: var(--kf-switch-thumb-size);
-	transform: translateX(-50%);
+	left: 0;
+	width: 100%;
 	border-radius: 9999px;
 	background-color: hsl(var(--kf-switch-thumb-bg));
 	mask: radial-gradient(
@@ -128,14 +114,13 @@
 	content: "";
 	position: absolute;
 	inset-block: 0;
-	left: 50%;
-	width: var(--kf-switch-thumb-size);
-	transform: translateX(-50%);
+	left: 0;
+	width: 100%;
 	border-radius: 9999px;
 	box-shadow: var(--kf-shadow-switch-thumb);
 }
 
-.switch-thumb[data-state="checked"] {
+.switch-root[data-state="checked"] .switch-thumb {
 	transform: translateX(var(--kf-switch-thumb-translate));
 }
 
@@ -144,10 +129,16 @@
 }
 
 /* Disabled thumb */
-.switch-thumb-disabled {
+.switch-root[data-disabled] .switch-thumb {
 	width: var(--kf-switch-thumb-size-disabled);
 	height: var(--kf-switch-thumb-size-disabled);
-	border-radius: 9999px;
-	background-color: hsl(var(--kf-switch-thumb-disabled));
 	box-shadow: none;
+	margin: calc(
+		(var(--kf-switch-thumb-size) - var(--kf-switch-thumb-size-disabled)) /
+		2
+	);
+}
+
+.switch-root[data-disabled][data-state="checked"] .switch-thumb {
+	transform: translateX(var(--kf-switch-thumb-translate));
 }

--- a/packages/elements/src/react/ui/components/switch.tsx
+++ b/packages/elements/src/react/ui/components/switch.tsx
@@ -24,7 +24,6 @@ export type SwitchStylesKeys = {
  */
 export interface SwitchProps
 	extends ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {
-	asChild?: boolean;
 	theme?: {
 		root: ExtendThemeKeys;
 		thumb: ExtendThemeKeys;
@@ -62,17 +61,14 @@ const Switch = forwardRef<
 			disabled={disabled}
 			{...rest}
 			{...switchRoot}
-			asChild
 		>
-			<span>
-				<Box
-					themeKey={theme?.track.themeKey ?? 'switch.track'}
-					baseClassName={['switch-track', disabled && 'switch-track-disabled']}
-					style={theme?.track.style}
-				>
-					<SwitchPrimitives.Thumb {...switchThumb} />
-				</Box>
-			</span>
+			<Box
+				themeKey={theme?.track.themeKey ?? 'switch.track'}
+				baseClassName={['switch-track', disabled && 'switch-track-disabled']}
+				style={theme?.track.style}
+			>
+				<SwitchPrimitives.Thumb {...switchThumb} />
+			</Box>
 		</SwitchPrimitives.Root>
 	);
 });


### PR DESCRIPTION
## Overview
Fixes the disabled state and the thumb not being centered of the switch

## Related Issue

Fixes #19, #30 

## Type of Change
<!-- Select ALL that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

### Visual Changes
<img width="453" alt="image" src="https://github.com/user-attachments/assets/561c1bde-cbfb-438d-baa6-e86f344d2267" />

## Checklist

### Required

- [x] Issue is linked
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [ ] Code follows style guide
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Revised the appearance of the toggle switch for clearer feedback on hover, active, and disabled states.
  - Disabled switches now display a distinct cursor and adjusted opacity for better inactiveness indication.

- **Refactor**
  - Streamlined the switch component structure by removing redundant elements and configuration options for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->